### PR TITLE
Adjust how settings are handled

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,4 @@
 [
-
-//Basic Key-Bindings
     { "keys": ["shift+enter"], "command": "new_zettel"},
     { "keys": ["ctrl+enter"], "command": "follow_wiki_link"},
     { "keys": ["[", "["], "command": "get_wiki_link"}

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,5 @@
+[
+    { "keys": ["shift+enter"], "command": "new_zettel"},
+    { "keys": ["ctrl+enter"], "command": "follow_wiki_link"},
+    { "keys": ["[", "["], "command": "get_wiki_link"}
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,5 @@
+[
+    { "keys": ["shift+enter"], "command": "new_zettel"},
+    { "keys": ["ctrl+enter"], "command": "follow_wiki_link"},
+    { "keys": ["[", "["], "command": "get_wiki_link"}
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,83 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Sublime ZK",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/sublime_zk/sublime_zk.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/sublime_zk.sublime-settings"},
+                                "caption": "Settings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/sublime_zk/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/sublime_zk/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/sublime_zk/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/sublime_zk.py
+++ b/sublime_zk.py
@@ -59,7 +59,7 @@ class FollowWikiLinkCommand(sublime_plugin.TextCommand):
         settings = sublime.load_settings('sublime_zk.sublime-settings')
         folder = os.path.dirname(self.view.window().project_file_name())
         extension = settings.get('wiki_extension', '.md')
-        id_in_title = settings.get('id_in_title', 'false').lower() != 'false'
+        id_in_title = settings.get('id_in_title')
 
         window = self.view.window()
         location = self.select_link()
@@ -107,7 +107,7 @@ class NewZettelCommand(sublime_plugin.WindowCommand):
         settings = sublime.load_settings('sublime_zk.sublime-settings')
         folder = os.path.dirname(self.window.project_file_name())
         extension = settings.get('wiki_extension', '.md')
-        id_in_title = settings.get('id_in_title', 'false').lower() != 'false'
+        id_in_title = settings.get('id_in_title')
 
         new_id = timestamp()
         the_file = os.path.join(folder,  new_id + ' ' + input_text + extension)
@@ -188,8 +188,7 @@ class NoteLinkHighlighter(sublime_plugin.EventListener):
     """The entry point. Find all LINKs in view, store and highlight them"""
     def update_note_link_highlights(self, view):
         settings = sublime.load_settings('sublime_zk.sublime-settings')
-        should_highlight = settings.get('highlight_note_links', 'True')
-        should_highlight = should_highlight.lower() != "false"
+        should_highlight = settings.get('highlight_note_links')
 
         max_note_link_limit = NoteLinkHighlighter.DEFAULT_MAX_LINKS
         if view.id() in NoteLinkHighlighter.ignored_views:
@@ -224,8 +223,7 @@ class NoteLinkHighlighter(sublime_plugin.EventListener):
     """
     def highlight_note_links(self, view, note_links):
         settings = sublime.load_settings('sublime_zk.sublime-settings')
-        show_bookmarks = settings.get('show_bookmarks', 'True')
-        show_bookmarks = show_bookmarks.lower() != "false"
+        show_bookmarks = settings.get('show_bookmarks_in_gutter')
 
         # We need separate regions for each lexical scope for ST to use a
         # proper color for the underline
@@ -241,7 +239,7 @@ class NoteLinkHighlighter(sublime_plugin.EventListener):
         self.update_view_scopes(view, scope_map.keys())
 
     """Apply underlining to provided regions."""
-    def underline_regions(self, view, scope_name, regions, show_bookmarks=True):
+    def underline_regions(self, view, scope_name, regions, show_bookmarks):
         if show_bookmarks:
             symbol = 'bookmark'
         else:

--- a/sublime_zk.sublime-settings
+++ b/sublime_zk.sublime-settings
@@ -3,14 +3,14 @@
     "wiki_extension": ".md",
 
     // when creating a new note, put id into title?
-     // "false" to disable
-    "id_in_title": "true",
+     // false to disable
+    "id_in_title": true,
 
     // highlight links to other notes?
-    // "false" to disable
-    "highlight_note_links": "true",
+    // false to disable
+    "highlight_note_links": true,
 
     // when highlighting: also show bookmark symbols in the gutter?
-    // "false" to disable
-    "show_bookmarks_in_gutter": "true"
+    // false to disable
+    "show_bookmarks_in_gutter": true
 }


### PR DESCRIPTION
Fixes #4 by adding beb9885 to break out keymaps into platform specific files. This is required for cross platform support since the default keymaps paths on each platform include the platform name (for example, the keymap file on windows is `Default (Windows).sublime-keymap`).

3bf55dd fixes #4 by adding a Settings menu to `Preferences > Packages Settings > Sublime ZK` and from there you can select the default settings for the plugin, or the user specific settings. User specific settings over-ride the default settings. 

Because of the changes made in the above commits, I adjusted how the plugin accesses the settings. Since we now have a default settings file that ships with the plugin, all the setting defaults are handled in that file, so in 963bbb4 we remove the default from the python itself, and change all true strings to boolean true, and all false strings to boolean false. Boolean true/false is preferred for sublime settings, and is the default method used in the main settings file.