### PR TITLE
Add option to disable auto_complete

### DIFF
--- a/sublime_zk.py
+++ b/sublime_zk.py
@@ -2321,6 +2321,10 @@ class NoteLinkHighlighter(sublime_plugin.EventListener):
         """
         Generate auto-completion entries for markdown files, based on
         """
+        settings = get_settings()
+        if not settings.get('enable_autocomplete', True):
+            return ([], 0)
+
         point = locations[0]
         if view.match_selector(point, 'text.html.markdown') == 0:
             return
@@ -2335,7 +2339,6 @@ class NoteLinkHighlighter(sublime_plugin.EventListener):
             return []
 
         # we have a path and are in markdown!
-        settings = get_settings()
         prefix, postfix = get_link_pre_postfix()
         extension = settings.get('wiki_extension')
         completions = []

--- a/sublime_zk.sublime-settings
+++ b/sublime_zk.sublime-settings
@@ -1,5 +1,4 @@
 {
-
     // The preferred markdown extension
     "wiki_extension": ".md",
 
@@ -81,4 +80,7 @@
 
     // set to true to enable super awesome zettelkasten mode
     "zettelkasten_mode" : true,
+
+    // set to false if you want to disable query completions while typing
+    "enable_autocomplete": false,
 }


### PR DESCRIPTION
When I use markdown files in large code bases, the auto-complete loading would delay a second when typing a word. Now, there is an option to disable auto-complete.