### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,13 @@ The following line in the plugin's settings turns MultiMarkdown mode on:
 "citations-mmd-style": true,
 ```
 
+#### Pandoc and CSL:
+
+Pandoc can generate bibliographies according to a referencing style. See: https://pandoc.org/MANUAL.html#specifying-a-citation-style
+
+You can control this behaviour by setting the `"csl_style": "/path/to/csl/style.csl"` setting in either User or the sublime_zk settings.
+Many CSL templates are freely [available](https://citationstyles.org/).
+
 ### Inline image preview size
 This plugin can [show local images](#inline-local-image-display) directly inside your note. To make sure that huge images won't steal too much of your screen, you can limit their size by width. Larger images will always be scaled to not exceed the maximum width.
 

--- a/sublime_zk.sublime-settings
+++ b/sublime_zk.sublime-settings
@@ -1,4 +1,6 @@
 {
+    // Specify CSL style for the bibliography generation.
+    "csl_style": "",
 
     // The preferred markdown extension
     "wiki_extension": ".md",


### PR DESCRIPTION
Original project no longer maintaind so numerous issues needed correcting/tidying:

- if user uses JabRef there will be '@comment' meta lines in user's bib file so use a negative lookbehind in citation regex to ignore them

- new zettels are now created in same sub-dir of zettel being created from (if using Linux) which is convenient if user has sub-dirs for fleeting-notes, project-notes, and literature-notes under main Zettelkasten project directory configured as Sublime_zk's project workspace location

- bibliography generation failure due to '--bibliography' switch behaviour change introduced in Pandoc 2.11 (see: https://pandoc.org/releases.html)

- also added a setting option to allow user to specify a CSL template to produce bibliography according to some referencing style standard

- properly increment bibliography item number by order cited when using IEEE CSL template