### PR TITLE
Fixed Auto-Bib generation error: (no bib generated)

### DIFF
--- a/sublime_zk.py
+++ b/sublime_zk.py
@@ -579,9 +579,10 @@ class Autobib:
 
     @staticmethod
     def dedupe(seq):
-        seen = set()
-        seen_add = seen.add
-        return [x for x in seq if not (x in seen or seen_add(x))]
+        """
+        Deduplicates input sequence
+        """
+        return list(dict.fromkeys(seq))
 
     @staticmethod
     def find_citations(text, citekeys):


### PR DESCRIPTION
`pandoc-citeproc` is now deprecated. Newer versions of `pandoc` internally uses `citeproc` library for conversion. With this PR, bibliography is autogenerated without losing the order. Earlier, second element of list of citation was getting associated with all citekeys.